### PR TITLE
Add option to regenerate folder guid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
+### 1.0.3 (2021.05.14)
+
+- **New**: Added option to include folders to the list of guids to be generated
+
 ### 1.0.2 (2021.02.21)
 
 - **New**: Support installation via UPM (Unity Package Manager)
-
 
 ### 1.0.1 (2020.08.21)
 

--- a/Editor/AssetGUIDRegenerator.cs
+++ b/Editor/AssetGUIDRegenerator.cs
@@ -50,9 +50,21 @@ namespace Jads.Tools
 {
     public class AssetGUIDRegeneratorMenu
     {
-        public static readonly string Version = "1.0.2";
-        [MenuItem("Assets/Regenerate GUID", true)]
+        public const string Version = "1.0.2";
+
+        [MenuItem("Assets/Regenerate GUID/Files Only", true)]
         public static bool RegenerateGUID_Validation()
+        {
+            return DoValidation();
+        }
+
+        [MenuItem("Assets/Regenerate GUID/Files and Folders", true)]
+        public static bool RegenerateGUIDWithFolders_Validation()
+        {
+            return DoValidation();
+        }
+
+        private static bool DoValidation()
         {
             var bAreSelectedAssetsValid = true;
 
@@ -65,10 +77,21 @@ namespace Jads.Tools
             return bAreSelectedAssetsValid;
         }
 
-        [MenuItem("Assets/Regenerate GUID")]
+        [MenuItem("Assets/Regenerate GUID/Files Only")]
         public static void RegenerateGUID_Implementation()
         {
-            var assetGUIDS = AssetGUIDRegenerator.ExtractGUIDs(Selection.assetGUIDs);
+            DoImplementation(false);
+        }
+
+        [MenuItem("Assets/Regenerate GUID/Files and Folders")]
+        public static void RegenerateGUIDWithFolders_Implementation()
+        {
+            DoImplementation(true);
+        }
+
+        private static void DoImplementation(bool includeFolders)
+        {
+            var assetGUIDS = AssetGUIDRegenerator.ExtractGUIDs(Selection.assetGUIDs, includeFolders);
 
             var option = EditorUtility.DisplayDialogComplex($"Regenerate GUID for {assetGUIDS.Length} asset/s",
                 "DISCLAIMER: Intentionally modifying asset GUID is not recommended unless certain issues are encountered. " +
@@ -133,8 +156,8 @@ namespace Jads.Tools
                         throw new ArgumentException($"The GUID of [{assetPath}] does not match the GUID in its meta file.");
                     }
 
-                    // Skip folders
-                    if (IsDirectory(assetPath)) continue;
+                    // Allow regenerating guid of folder because modifying it doesn't seem to be harmful
+                    // if (IsDirectory(assetPath)) continue;
 
                     // Skip scene files
                     if (assetPath.EndsWith(".unity"))
@@ -157,6 +180,13 @@ namespace Jads.Tools
                     File.WriteAllText(metaPath, metaContents);
 
                     if (bIsInitiallyHidden) UnhideFile(metaPath, metaAttributes);
+
+                    if (IsDirectory(assetPath))
+                    {
+                        // Skip PART 2 for directories as they should not have any references in assets or scenes
+                        updatedAssets.Add(AssetDatabase.GUIDToAssetPath(selectedGUID), 0);
+                        continue;
+                    }
 
                     /*
                      * PART 2 - Update the GUID for all assets that references the selected GUID
@@ -210,7 +240,7 @@ namespace Jads.Tools
         }
 
         // Searches for Directories and extracts all asset guids inside it using AssetDatabase.FindAssets
-        public static string[] ExtractGUIDs(string[] selectedGUIDs)
+        public static string[] ExtractGUIDs(string[] selectedGUIDs, bool includeFolders)
         {
             var finalGuids = new List<string>();
             foreach (var guid in selectedGUIDs)
@@ -219,6 +249,8 @@ namespace Jads.Tools
                 if (IsDirectory(assetPath))
                 {
                     string[] searchDirectory = {assetPath};
+
+                    if (includeFolders) finalGuids.Add(guid);
                     finalGuids.AddRange(AssetDatabase.FindAssets(SearchFilter, searchDirectory));
                 }
                 else
@@ -242,7 +274,7 @@ namespace Jads.Tools
             File.SetAttributes(path, attributes);
         }
 
-        private static bool IsDirectory(string path) => File.GetAttributes(path).HasFlag(FileAttributes.Directory);
+        public static bool IsDirectory(string path) => File.GetAttributes(path).HasFlag(FileAttributes.Directory);
     }
 }
 

--- a/Editor/AssetGUIDRegenerator.cs
+++ b/Editor/AssetGUIDRegenerator.cs
@@ -50,7 +50,7 @@ namespace Jads.Tools
 {
     public class AssetGUIDRegeneratorMenu
     {
-        public const string Version = "1.0.2";
+        public const string Version = "1.0.3";
 
         [MenuItem("Assets/Regenerate GUID/Files Only", true)]
         public static bool RegenerateGUID_Validation()

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 A Unity editor tool to regenerate GUID for your assets
 
-> **Disclaimer**: Only use this if needed. Intentionally modifying the GUID of an asset is not recommended unless certain issues are encountered
+> :warning: **Disclaimer**: Only use this if needed. Intentionally modifying the GUID of an asset is not recommended unless certain files are problematic
 
 ## What is GUID in Unity?
 GUID is a unique hash that is automatically generated and assigned when creating a new asset. This GUID is used when a serialized asset references another asset.
@@ -17,6 +17,11 @@ When you work on multiple projects that are based on existing projects, chances 
 
 The simplest workaround for this is to duplicate the asset. The newly created asset will have its own GUID assigned by Unity. However, you will need to manually replace all its references in the Scene, prefabs, etc.
 
+## Installation
+1. Unity Editor > Windows > Package Manager
+2. Add package from git URL...
+3. Enter `https://github.com/jeffjadulco/unity-guid-regenerator.git`
+
 ## Usage
 ![inst](assets/instructions-1.png)
 1. Select one or multiple assets (folders are not supported)
@@ -27,11 +32,6 @@ The simplest workaround for this is to duplicate the asset. The newly created as
 
 ## Notes
 - Scenes are always skipped as this corrupts the scene.
-
-## Installation
-1. Unity Editor > Windows > Package Manager
-2. Add package from git URL...
-3. Enter `https://github.com/jeffjadulco/unity-guid-regenerator.git`
 
 ## Author
 - [Jeff Jadulco](https://github.com/jeffjads)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.jeffjadulco.guidregenerator",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "displayName": "GUID Regenerator",
   "description": "A Unity editor tool to regenerate GUID for your assets",
   "unity": "2019.4",


### PR DESCRIPTION
### Changes
- Added an option to regenerate guid for `Files Only` or `Files and Folders`

![image](https://user-images.githubusercontent.com/12724975/118344054-ddf05300-b55e-11eb-807e-a483b3abdc2d.png)

### Reason
- Regenerating folder guid doesn't seem to be harmful 

### Closes #4 
